### PR TITLE
Fixed hang during dumping

### DIFF
--- a/dumper.py
+++ b/dumper.py
@@ -19,7 +19,7 @@ def dump_to_file(session,base,size,error,directory):
 #Read bytes that are bigger than the max_size value, split them into chunks and save them to a file
 
 def splitter(session,base,size,max_size,error,directory):
-        times = size/max_size
+        times = size//max_size
         diff = size % max_size
         if diff is 0:
             logging.debug("Number of chunks:"+str(times+1))


### PR DESCRIPTION
Fixed hang during dumping:
Creating directory...
Starting Memory dump...
Traceback (most recent call last):---------------------------] 0.2% Complete
  File "fridump.py", line 113, in <module>
    mem_access_viol = dumper.splitter(session, base, size, MAX_SIZE, mem_access_viol, DIRECTORY)
  File "E:\tools\fridump\dumper.py", line 31, in splitter
    for time in range(times):
TypeError: 'float' object cannot be interpreted as an integer